### PR TITLE
BUG: extend range for finding latest historical results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .DS_Store
 *.db
 sample_project/repos/*
+speed_pypy/repos/*
 override
 build
 dist


### PR DESCRIPTION
This gives a little more headroom to transition "latest" to an active environment. 

The problem is we would like to compare "latest" from the same environment as specified in `settings.DEF_ENVIRONMENT`, but what happens if that environment is no longer active (as happens on speed.pypy.org where we have historical results from one machine but now run benchmarks on another). Since `Revision` does not specify an environment, we need to do a `JOIN`, which the code simulates by going back 100 results and then looking for a match