### PR TITLE
updates to codespeed for hg hash, pypy3.9, links on about page

### DIFF
--- a/codespeed/results.py
+++ b/codespeed/results.py
@@ -79,7 +79,9 @@ def save_result(data, update_repo=True):
         # "None" (as string) can happen when we urlencode the POST data
         if not rev_date or rev_date in ["", "None"]:
             rev_date = datetime.today()
-        rev = Revision(branch=branch, project=p, commitid=data['commitid'],
+        # Only take the hash of a mercurial nnn:xxxhash commitid
+        rev = Revision(branch=branch, project=p,
+                       commitid=data['commitid'].split(':')[-1],
                        date=rev_date)
         try:
             rev.full_clean()

--- a/speed_pypy/settings.py
+++ b/speed_pypy/settings.py
@@ -87,8 +87,8 @@ STATICFILES_DIRS = (
 
 SHOW_REPORTS = False
 SHOW_HISTORICAL = True
-DEF_BASELINE = {'executable': 'cpython', 'revision': '3.6.7'}
-DEF_EXECUTABLE = {'name': 'pypy3-jit-64', 'project': 'PyPy3.7'}
+DEF_BASELINE = {'executable': 'cpython', 'revision': '3.6.8'}
+DEF_EXECUTABLE = {'name': 'pypy3.9-jit-64', 'project': 'PyPy3.9'}
 DEF_ENVIRONMENT = 'benchmarker'
 
 

--- a/speed_pypy/templates/about.html
+++ b/speed_pypy/templates/about.html
@@ -5,25 +5,26 @@
 </div>
 <div id="about" class="about_content clearfix">
 <h3>About this site</h3>
-<p>We have nightly benchmark runs of pypy, together with cpython 2.6.2 data for comparison.</p>
+<p>We have nightly benchmark runs of pypy, together with cpython data for comparison.</p>
 <p>This site runs on top of Django and Codespeed</p>
 <h3>About the benchmarks</h3>
-<p>The code can be found <a href="https://bitbucket.org/pypy/benchmarks">here</a>.</p>
+<p>The benchmark code can be found <a
+href="https://foss.heptapod.net/pypy/benchmarks">here</a>.</p>
 <p>This is a benchmark suite based on Unladen Swallow, adapted for PyPY and
-runs on Python2. For a port of these benchmarks to Python3 see <a
+runs on Python2 and Python3. Also see <a
 href="https://speed.python.org">the python speed site</a></p>
 <h3>About PyPy</h3>
 <p>PyPy is a very compliant implementation of the Python language.</p>
-<p>Main website: <a href="http://www.pypy.org">pypy.org</a></p>
+<p>Main website: <a href="https://www.pypy.org">www.pypy.org</a></p>
 
-<p>Blog: <a href="http://morepypy.blogspot.com/">morepypy.blogspot.com</a>
+<p>Blog: <a href="https://www.pypy.org/blog/">www.pypy.org/blog/</a>
 <h3>About Codespeed</h3>
 Codespeed is a web application to monitor and analyze the performance of your code.
-<p>Code: <a href="http://github.com/tobami/codespeed">github.com/tobami/codespeed</a></p>
-<p>Wiki: <a href="http://wiki.github.com/tobami/codespeed/">wiki.github.com/tobami/codespeed/</a></p>
+<p>Code: <a href="https://github.com/python/codespeed/tree/speed.pypy.org">PyPy branch of python fork of codespeed</a>
+<p>Wiki: <a href="https://wiki.github.com/tobami/codespeed/">wiki.github.com/tobami/codespeed/</a></p>
 <h3>Contact</h3>
 <p>For problems or suggestions about this website write to</p>
-<p>the <a href="http://codespeak.net/mailman/listinfo/pypy-dev">pypy-dev mailing list</a> or directly to Miquel Torres (tobami at googlemail dot com)</p>
+<p>the <a href="https://pypy.org/contact/">PyPy team</a> or directly to Miquel Torres (tobami at googlemail dot com)</p>
 
 </div>
 {% endblock %}


### PR DESCRIPTION
- Use the hg hash as a commitid rather than the commit-number:hash in order to avoid problems with commit numbering across repositories
- Use PyPy3.9 as the version to track on the bar graph on the front page
- Update the [about page](https://speed.pypy.org/about/) with better links and text.