### PR TITLE
Update codespeed dependencies to be compatible with Python3.8

### DIFF
--- a/codespeed/models.py
+++ b/codespeed/models.py
@@ -9,14 +9,12 @@ from django.core.exceptions import ValidationError
 from django.urls import reverse
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from .commits.github import GITHUB_URL_RE
 
 logger = logging.getLogger(__name__)
 
 
-@python_2_unicode_compatible
 class Project(models.Model):
     NO_LOGS = 'N'
     GIT = 'G'
@@ -107,7 +105,6 @@ class HistoricalValue(object):
             return False
 
 
-@python_2_unicode_compatible
 class Branch(models.Model):
     name = models.CharField(max_length=32)
     project = models.ForeignKey(
@@ -124,7 +121,6 @@ class Branch(models.Model):
         verbose_name_plural = "branches"
 
 
-@python_2_unicode_compatible
 class Revision(models.Model):
     # git and mercurial's SHA-1 length is 40
     commitid = models.CharField(max_length=42)
@@ -167,7 +163,6 @@ class Revision(models.Model):
                 raise ValidationError("Invalid SVN commit id %s" % self.commitid)
 
 
-@python_2_unicode_compatible
 class Executable(models.Model):
     name = models.CharField(max_length=30)
     description = models.CharField(max_length=200, blank=True)
@@ -181,7 +176,6 @@ class Executable(models.Model):
         return self.name
 
 
-@python_2_unicode_compatible
 class Benchmark(models.Model):
     B_TYPES = (
         ('C', 'Cross-project'),
@@ -216,7 +210,6 @@ class Benchmark(models.Model):
                                   "'default_on_comparison' first.")
 
 
-@python_2_unicode_compatible
 class Environment(models.Model):
     name = models.CharField(unique=True, max_length=100)
     cpu = models.CharField(max_length=100, blank=True)
@@ -228,7 +221,6 @@ class Environment(models.Model):
         return self.name
 
 
-@python_2_unicode_compatible
 class Result(models.Model):
     value = models.FloatField()
     std_dev = models.FloatField(blank=True, null=True)
@@ -253,7 +245,6 @@ class Result(models.Model):
         unique_together = ("revision", "executable", "benchmark", "environment")
 
 
-@python_2_unicode_compatible
 class Report(models.Model):
     revision = models.ForeignKey(
         Revision, on_delete=models.CASCADE, related_name="reports")

--- a/codespeed/templates/codespeed/changes_data.html
+++ b/codespeed/templates/codespeed/changes_data.html
@@ -17,13 +17,13 @@
     <td>{% if rev.get_browsing_url %}<a href="{{ rev.get_browsing_url }}">{{ rev.commitid }}</a>{% else %}{{ rev.commitid }}{% endif %}</td>
   </tr>
   <tr class="date"><th class="infofirst">Date</td><td>{{ rev.date }}</td></tr>
-  {% ifnotequal rev.branch.project.repo_type "N" %}
+  {% if rev.branch.project.repo_type != "N" %}
     <tr class="repo-path"><th class="infofirst">Repo</th><td>{{ rev.branch.project.repo_path }}</td></tr>
-  {% endifnotequal %}
+  {% endif %}
 </tbody>
 </table>
 
-{% ifnotequal exe.project.repo_type 'N' %}
+{% if exe.project.repo_type != 'N' %}
   <table class="revision">
       <col/>
       <col/>
@@ -40,5 +40,5 @@
       el.load("logs/", "revisionid=" + el.data("commitid"));
     </script>
 </table>
-{% endifnotequal %}
+{% endif %}
 </div>

--- a/codespeed/templates/codespeed/changes_table.html
+++ b/codespeed/templates/codespeed/changes_table.html
@@ -26,7 +26,7 @@
     {% endif%}{% if units.has_stddev %}<td>{{ units.totals.min }}</td>
     {% endif%}{% if units.hasmax %}<td>{{ units.totals.max }}</td>
     {% endif%}<td>{{ units.totals.change|percentage }}</td>
-    <td>{% ifnotequal units.totals.trend "-" %}{{ units.totals.trend|floatformat:2 }}%{% else %}{{ units.totals.trend }}{% endifnotequal %}</td>
+    <td>{% if units.totals.trend != "-" %}{{ units.totals.trend|floatformat:2 }}%{% else %}{{ units.totals.trend }}{% endif %}</td>
   </tr>
 </tfoot>
 <tbody>
@@ -38,7 +38,7 @@
     {% endif%}{% if units.hasmin %}<td>{{ row.val_min|floatformat:units.precission }}</td>
     {% endif%}{% if units.hasmax %}<td>{{ row.val_max|floatformat:units.precission }}</td>
     {% endif%}<td>{{ row.change|percentage }}</td>
-    <td>{% ifequal row.trend "-" %}-{% else %}{{ row.trend|floatformat:2 }}%{% endifequal %}</td>
+    <td>{% if row.trend == "-" %}-{% else %}{{ row.trend|floatformat:2 }}%{% endif %}</td>
   </tr>{% endfor %}
 </tbody>
 </table>{% endfor %}

--- a/codespeed/templates/codespeed/timeline.html
+++ b/codespeed/templates/codespeed/timeline.html
@@ -54,7 +54,7 @@
 </div>
 <div id="benchmark" class="sidebox">
   <div class="boxhead"><h2>Benchmark</h2></div>
-  <div class="boxbody">{% ifnotequal benchmarks|length 1 %}
+  <div class="boxbody">{% if benchmarks|length != 1 %}
   <ul>
     <li>
       <input id="benchmarkgrid" type="radio" name="benchmark" value="grid" />
@@ -64,7 +64,7 @@
       <input id="b_show_none" type="radio" name="benchmark" value="show_none" />
       <label for="b_show_none">Display none</label>
     </li>
-  </ul>{% endifnotequal %}
+  </ul>{% endif %}
   <ul>{% for bench in benchmarks|dictsort:"name" %}
     <li title="{{ bench.description }}">
       <input id="benchmark_{{ bench.id }}" type="radio" name="benchmark" value="{{ bench.name }}" />

--- a/codespeed/urls.py
+++ b/codespeed/urls.py
@@ -1,35 +1,35 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls import url
+from django.urls import re_path
 from django.views.generic import TemplateView
 
 from codespeed import views
 from codespeed.feeds import LatestEntries, LatestSignificantEntries
 
 urlpatterns = [
-    url(r'^$', views.HomeView.as_view(), name='home'),
-    url(r'^about/$',
+    re_path(r'^$', views.HomeView.as_view(), name='home'),
+    re_path(r'^about/$',
         TemplateView.as_view(template_name='about.html'), name='about'),
     # RSS for reports
-    url(r'^feeds/latest/$', LatestEntries(), name='latest-results'),
-    url(r'^feeds/latest_significant/$', LatestSignificantEntries(),
+    re_path(r'^feeds/latest/$', LatestEntries(), name='latest-results'),
+    re_path(r'^feeds/latest_significant/$', LatestSignificantEntries(),
         name='latest-significant-results'),
 ]
 
 urlpatterns += [
-    url(r'^historical/json/$', views.gethistoricaldata, name='gethistoricaldata'),
-    url(r'^reports/$', views.reports, name='reports'),
-    url(r'^changes/$', views.changes, name='changes'),
-    url(r'^changes/table/$', views.getchangestable, name='getchangestable'),
-    url(r'^changes/logs/$', views.displaylogs, name='displaylogs'),
-    url(r'^timeline/$', views.timeline, name='timeline'),
-    url(r'^timeline/json/$', views.gettimelinedata, name='gettimelinedata'),
-    url(r'^comparison/$', views.comparison, name='comparison'),
-    url(r'^comparison/json/$', views.getcomparisondata, name='getcomparisondata'),
-    url(r'^makeimage/$', views.makeimage, name='makeimage'),
+    re_path(r'^historical/json/$', views.gethistoricaldata, name='gethistoricaldata'),
+    re_path(r'^reports/$', views.reports, name='reports'),
+    re_path(r'^changes/$', views.changes, name='changes'),
+    re_path(r'^changes/table/$', views.getchangestable, name='getchangestable'),
+    re_path(r'^changes/logs/$', views.displaylogs, name='displaylogs'),
+    re_path(r'^timeline/$', views.timeline, name='timeline'),
+    re_path(r'^timeline/json/$', views.gettimelinedata, name='gettimelinedata'),
+    re_path(r'^comparison/$', views.comparison, name='comparison'),
+    re_path(r'^comparison/json/$', views.getcomparisondata, name='getcomparisondata'),
+    re_path(r'^makeimage/$', views.makeimage, name='makeimage'),
 ]
 
 urlpatterns += [
     # URLs for adding results
-    url(r'^result/add/json/$', views.add_json_results, name='add-json-results'),
-    url(r'^result/add/$', views.add_result, name='add-result'),
+    re_path(r'^result/add/json/$', views.add_json_results, name='add-json-results'),
+    re_path(r'^result/add/$', views.add_result, name='add-result'),
 ]

--- a/codespeed/views.py
+++ b/codespeed/views.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.http import HttpResponse, Http404, HttpResponseBadRequest, \
     HttpResponseNotFound, StreamingHttpResponse
 from django.db.models import F
-from django.shortcuts import get_object_or_404, render_to_response
+from django.shortcuts import get_object_or_404, render
 from django.views.decorators.http import require_GET, require_POST
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import TemplateView
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 def no_environment_error(request):
     admin_url = reverse('admin:codespeed_environment_changelist')
-    return render_to_response('codespeed/nodata.html', {
+    return render(request, 'codespeed/nodata.html', {
         'message': ('You need to configure at least one Environment. '
                     'Please go to the '
                     '<a href="%s">admin interface</a>' % admin_url)
@@ -42,7 +42,7 @@ def no_environment_error(request):
 
 def no_default_project_error(request):
     admin_url = reverse('admin:codespeed_project_changelist')
-    return render_to_response('codespeed/nodata.html', {
+    return render(request, 'codespeed/nodata.html', {
         'message': ('You need to configure at least one one Project as '
                     'default (checked "Track changes" field).<br />'
                     'Please go to the '
@@ -51,13 +51,13 @@ def no_default_project_error(request):
 
 
 def no_executables_error(request):
-    return render_to_response('codespeed/nodata.html', {
+    return render(request, 'codespeed/nodata.html', {
         'message': 'There needs to be at least one executable'
     })
 
 
 def no_data_found(request):
-    return render_to_response('codespeed/nodata.html', {
+    return render(request, 'codespeed/nodata.html', {
         'message': 'No data found'
     })
 
@@ -309,7 +309,7 @@ def comparison(request):
             settings.CHART_ORIENTATION == 'horizontal'):
         selecteddirection = True
 
-    return render_to_response('codespeed/comparison.html', {
+    return render(request, 'codespeed/comparison.html', {
         'checkedexecutables': checkedexecutables,
         'checkedbenchmarks': checkedbenchmarks,
         'checkedenviros': checkedenviros,
@@ -623,7 +623,7 @@ def timeline(request):
     for proj in Project.objects.filter(track=True):
         executables[proj] = Executable.objects.filter(project=proj)
     use_median_bands = hasattr(settings, 'USE_MEDIAN_BANDS') and settings.USE_MEDIAN_BANDS
-    return render_to_response('codespeed/timeline.html', {
+    return render(request, 'codespeed/timeline.html', {
         'pagedesc': pagedesc,
         'checkedexecutables': checkedexecutables,
         'defaultbaseline': defaultbaseline,
@@ -707,7 +707,7 @@ def getchangestable(request):
                             '<p class="errormessage">No results for this '
                             'parameters</p>')
 
-    return render_to_response('codespeed/changes_data.html', {
+    return render(request, 'codespeed/changes_data.html', {
         'tablelist': tablelist,
         'trendconfig': trendconfig,
         'rev': selectedrev,
@@ -813,7 +813,7 @@ def changes(request):
 
     pagedesc = "Report of %s performance changes for commit %s on branch %s" % \
         (defaultexecutable, selectedrevision.commitid, selectedrevision.branch)
-    return render_to_response('codespeed/changes.html', {
+    return render(request, 'codespeed/changes.html', {
         'pagedesc': pagedesc,
         'defaultenvironment': defaultenv,
         'defaultexecutable': defaultexecutable,
@@ -840,7 +840,7 @@ def reports(request):
         colorcode__in=('red', 'green')
     ).order_by('-revision__date')[:10]
 
-    return render_to_response('codespeed/reports.html', context)
+    return render(request, 'codespeed/reports.html', context)
 
 
 @require_GET
@@ -885,7 +885,8 @@ def displaylogs(request):
     for log in logs:
         log['commit_browse_url'] = project.commit_browsing_url.format(**log)
 
-    return render_to_response(
+    return render(
+        request,
         'codespeed/changes_logs.html',
         {
             'error': error, 'logs': logs,

--- a/deploy-requirements.txt
+++ b/deploy-requirements.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
-psycopg2==2.9.3
-gunicorn==20.1.0
+psycopg-binary==3.1.17
+gunicorn==21.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django>=1.11,<2.2
-isodate>=0.4.7,<0.6
-matplotlib>=1.4.3,<2.0
+django<4
+isodate==0.6.1
+matplotlib<3.8

--- a/sample_project/templates/feeds/latest_description.html
+++ b/sample_project/templates/feeds/latest_description.html
@@ -1,8 +1,8 @@
-{% ifequal obj.colorcode "red" %}Performance regressed: {% else %}
-    {% ifequal obj.colorcode "green" %}Performance improved: {% else %}
-        {% ifequal obj.colorcode "yellow" %}Trend regressed: {% else %}
+{% if obj.colorcode == "red" %}Performance regressed: {% else %}
+    {% if obj.colorcode == "green" %}Performance improved: {% else %}
+        {% if obj.colorcode == "yellow" %}Trend regressed: {% else %}
             No significant changes.
-        {% endifequal %}
-    {% endifequal %}
-{% endifequal %}
+        {% endif %}
+    {% endif %}
+{% endif %}
 {{ obj.summary }}

--- a/sample_project/urls.py
+++ b/sample_project/urls.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from django.contrib import admin
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^', include('codespeed.urls'))
+    re_path(r'^admin/', admin.site.urls),
+    re_path(r'^', include('codespeed.urls'))
 ]
 
 if settings.DEBUG:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     download_url="https://github.com/tobami/codespeed/tags",
     license='GNU Lesser General Public License version 2.1',
     keywords=['benchmarking', 'visualization'],
-    install_requires=['django>=1.11<2.2', 'isodate>=0.4.7,<0.6', 'matplotlib>=1.4.3,<2.0'],
+    install_requires=[ 'django', 'isodate', 'matplotlib'],
     packages=find_packages(exclude=['ez_setup', 'sample_project', 'speed_python']),
     setup_requires=['setuptools-markdown'],
     long_description_markdown_filename='README.md',

--- a/speed_python/settings.py
+++ b/speed_python/settings.py
@@ -106,6 +106,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'codespeed',
+    'gunicorn',
 )
 
 STATIC_URL = '/static/'

--- a/speed_python/settings.py
+++ b/speed_python/settings.py
@@ -22,6 +22,7 @@ DATABASES = {
         'NAME': os.path.join(BASEDIR, 'data.db'),
     }
 }
+DEFAULT_AUTO_FIELD='django.db.models.AutoField'
 
 TIME_ZONE = 'America/Chicago'
 
@@ -46,7 +47,7 @@ TEMPLATE_LOADERS = (
     'django.template.loaders.app_directories.Loader',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -60,40 +61,51 @@ if DEBUG:
 
     # Define a class that logs unhandled errors
     class LogUncatchedErrors:
+        def __init__(self, get_response):
+            self.get_response = get_response
+
+        def __call__(self, request):
+            return self.get_response(request)
+
         def process_exception(self, request, exception):
             logging.error("Unhandled Exception on request for %s\n%s" %
                                  (request.build_absolute_uri(),
                                   traceback.format_exc()))
     # And add it to the middleware classes
-    MIDDLEWARE_CLASSES += ('speed_python.settings.LogUncatchedErrors',)
+    MIDDLEWARE += ('speed_python.settings.LogUncatchedErrors',)
 
     # set shown level of logging output to debug
     logging.basicConfig(level=logging.DEBUG)
 
 ROOT_URLCONF = '{0}.urls'.format(TOPDIR)
 
-TEMPLATE_DIRS = (
-    os.path.join(BASEDIR, 'templates'),
-)
-
-TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.contrib.auth.context_processors.auth',
-    'django.contrib.messages.context_processors.messages',
-    'django.core.context_processors.debug',
-    'django.core.context_processors.i18n',
-    'django.core.context_processors.media',
-    'django.core.context_processors.static',
-    'django.core.context_processors.request',
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [os.path.join(BASEDIR, 'templates')],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.request',
+            ],
+        },
+    },
+]
 
 INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.admin',
+    'django.contrib.messages',
     'django.contrib.staticfiles',
     'codespeed',
-    'gunicorn',
 )
 
 STATIC_URL = '/static/'

--- a/speed_python/templates/feeds/latest_description.html
+++ b/speed_python/templates/feeds/latest_description.html
@@ -1,8 +1,8 @@
-{% ifequal obj.colorcode "red" %}Performance regressed: {% else %}
-    {% ifequal obj.colorcode "green" %}Performance improved: {% else %}
-        {% ifequal obj.colorcode "yellow" %}Trend regressed: {% else %}
+{% if obj.colorcode == "red" %}Performance regressed: {% else %}
+    {% if obj.colorcode == "green" %}Performance improved: {% else %}
+        {% if obj.colorcode == "yellow" %}Trend regressed: {% else %}
             No significant changes.
-        {% endifequal %}
-    {% endifequal %}
-{% endifequal %}
+        {% endif %}
+    {% endif %}
+{% endif %}
 {{ obj.summary }}

--- a/speed_python/templates/home.html
+++ b/speed_python/templates/home.html
@@ -1,5 +1,4 @@
 {% extends "codespeed/base_site.html" %}
-{% load url from future %}
 
 {% block navigation %}
 {% endblock navigation %}

--- a/speed_python/urls.py
+++ b/speed_python/urls.py
@@ -3,17 +3,16 @@
 import os.path
 
 from django.conf import settings
-from django.conf.urls import patterns, include
+from django.urls import include, re_path
 from django.views.generic import RedirectView
-from django.core.urlresolvers import reverse
 from django.contrib import admin
 
 admin.autodiscover()
 
-urlpatterns = patterns('',
-    (r'^admin/', include(admin.site.urls)),
-    (r'^', include('codespeed.urls')),
-)
+urlpatterns = [
+    re_path(r'^admin/', admin.site.urls),
+    re_path(r'^', include('codespeed.urls')),
+]
 
 if settings.DEBUG:
     # needed for development server


### PR DESCRIPTION
Update codespeed dependencies.
Update codebase to reflect API changes of new dependencies. Also this drops support for Python 2 and it can be run with Python 3.8 Pin dependencies in requirements files.

PR related to https://github.com/python/codespeed/issues/30