### PR TITLE
Add (All, None) selector on environments list

### DIFF
--- a/codespeed/templates/codespeed/comparison.html
+++ b/codespeed/templates/codespeed/comparison.html
@@ -19,12 +19,13 @@
 <div class="sidebox">
   <div class="boxhead"><h2>Environments</h2></div>
   <div class="boxbody">
-    <ul>{% for env in enviros %}
+  <ul><a href="#" class="togglefold">Environments</a> <a href="#" class="checkall">(All</a>, <a href="#" class="uncheckall">None)</a>
+    {% for env in enviros %}
       <li title="{{ env.os }}, {{ env.cpu }}">
         <input id="env_{{ env.id }}" type="checkbox" name="environments" value="{{ env.id }}" />
         <label for="env_{{ env.id }}">{{ env }}</label>
       </li>{% endfor %}
-    </ul>
+  </ul>
   </div>
 </div>
 <div id="executable" class="sidebox">


### PR DESCRIPTION
In the comparison page there are selectors on executables and benchmarks. As we have quite few environents it's good to have the same selector on the environments list

PR related to https://github.com/python/codespeed/issues/31