### PR TITLE
Pin psycopg2 dependency

### DIFF
--- a/deploy-requirements.txt
+++ b/deploy-requirements.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
-psycopg-binary==3.1.17
+psycopg2==2.9.9
 gunicorn==21.2.0


### PR DESCRIPTION
We are using Django 3.2 which doesn't support pyscopg 3.1.8. Django 4.2 introduces support for psycopg 3.1.8.
More info: https://docs.djangoproject.com/en/5.0/ref/databases/#postgresql-notes