### PR TITLE
Show full date/time in the revision admin view

### DIFF
--- a/codespeed/models.py
+++ b/codespeed/models.py
@@ -144,7 +144,7 @@ class Revision(models.Model):
         if self.date is None:
             date = None
         else:
-            date = self.date.strftime("%b %d, %H:%M")
+            date = self.date.isoformat(sep=" ")
         string = " - ".join(filter(None, (date, self.commitid, self.tag)))
         if self.branch.name != self.branch.project.default_branch:
             string += " - " + self.branch.name


### PR DESCRIPTION
When a revision is shown in the admin interface, the year of the date is not displayed. Change to isoformat to show every field of the DateTimeField.
Address https://github.com/python/codespeed/issues/23