### PR TITLE
Always show the branch name in the Revision

### DIFF
--- a/codespeed/models.py
+++ b/codespeed/models.py
@@ -145,9 +145,7 @@ class Revision(models.Model):
             date = None
         else:
             date = self.date.isoformat(sep=" ")
-        string = " - ".join(filter(None, (date, self.commitid, self.tag)))
-        if self.branch.name != self.branch.project.default_branch:
-            string += " - " + self.branch.name
+        string = " - ".join(filter(None, (date, self.commitid, self.tag, self.branch.name)))
         return string
 
     class Meta:


### PR DESCRIPTION
When rendering revisions in the Django admin, always show the branch name.