### PR TITLE
speed.pypy.org: Remove space before colons in page titles

### DIFF
--- a/speed_pypy/templates/codespeed/base_site.html
+++ b/speed_pypy/templates/codespeed/base_site.html
@@ -1,5 +1,3 @@
 {% extends "codespeed/base.html" %}
 
-{% block title %}
-	PyPy Speed
-{% endblock %}
+{% block title %}PyPy Speed{% endblock %}


### PR DESCRIPTION
Before:

<img width="915" height="157" alt="image" src="https://github.com/user-attachments/assets/4ba331a9-0a1a-4185-9ced-0c70cd6f6097" />

After:

<img width="624" height="137" alt="image" src="https://github.com/user-attachments/assets/05b27bfd-ce1f-4d40-b620-2ac8e049a8e6" />
