### PR TITLE
speed.python.org: Remove space before colons in page titles

### DIFF
--- a/speed_python/templates/codespeed/base_site.html
+++ b/speed_python/templates/codespeed/base_site.html
@@ -1,5 +1,3 @@
 {% extends "codespeed/base.html" %}
 
-{% block title %}
-	Python Speed Center
-{% endblock %}
+{% block title %}Python Speed Center{% endblock %}


### PR DESCRIPTION
Same as https://github.com/python/codespeed/pull/63, but for speed.python.org.