### PR TITLE
prevent uploading a revision that already exists to a different branch

### DIFF
--- a/codespeed/admin.py
+++ b/codespeed/admin.py
@@ -55,6 +55,7 @@ class RevisionAdmin(admin.ModelAdmin):
     list_display = ('commitid', 'branch', 'tag', 'date')
     list_filter = ('branch__project', 'branch', 'tag', 'date')
     search_fields = ('commitid', 'tag')
+    raw_id_fields = ('branch',)
 
 
 @admin.register(Executable)
@@ -87,6 +88,7 @@ class ResultAdmin(admin.ModelAdmin):
     list_display = ('revision', 'benchmark', 'executable', 'environment',
                     'value', 'date')
     list_filter = ('environment', 'executable', 'date', 'benchmark')
+    raw_id_fields = ('revision', 'benchmark', 'executable', 'environment')
 
 
 def recalculate_report(modeladmin, request, queryset):

--- a/codespeed/results.py
+++ b/codespeed/results.py
@@ -77,13 +77,23 @@ def save_result(data, update_repo=True):
     try:
         rev = branch.revisions.get(commitid=data['commitid'].split(":")[-1])
     except Revision.DoesNotExist:
+        commitid = data['commitid'].split(':')[-1]
+        conflict = Revision.objects.filter(
+            commitid=commitid, branch__project=p
+        ).exclude(branch=branch).first()
+        if conflict:
+            return (
+                "Revision %s already exists on branch '%s'; "
+                "refusing to add it to branch '%s'" % (
+                    commitid, conflict.branch.name, data['branch'])
+            ), True
         rev_date = data.get("revision_date")
         # "None" (as string) can happen when we urlencode the POST data
         if not rev_date or rev_date in ["", "None"]:
             rev_date = datetime.today()
         # Only take the hash of a mercurial nnn:xxxhash commitid
         rev = Revision(branch=branch, project=p,
-                       commitid=data['commitid'].split(':')[-1],
+                       commitid=commitid,
                        date=rev_date)
         try:
             rev.full_clean()


### PR DESCRIPTION
When uploading, the uploader specifies a revision and its branch. If that revision already exists, do not allow creating an association to a different branch.

Also do not populate pulldowns in the admin panel with too many values, it times out and presents a "server hiccup"