### PR TITLE
allow up to two environments on timeline and other smaller fixes

### DIFF
--- a/codespeed/static/css/main.css
+++ b/codespeed/static/css/main.css
@@ -234,6 +234,7 @@ div.about_content { text-align: left; }
 .boxbody input { margin-left: 0; vertical-align: top; }
 #options li { margin-bottom: 0.8em; }
 .seriescolor { float: right; margin-top: 2px; height: 13px; width: 14px; }
+.envlinecolor { float: right; font-size: 12px; line-height: 18px; color: #555; }
 .compplot-wrap { display: inline-block; }
 a.togglefold { font-size: normal; color: #000000; }
 a.togglefold::before {

--- a/codespeed/static/js/changes.js
+++ b/codespeed/static/js/changes.js
@@ -93,6 +93,9 @@ function updateRevisionMarkers(env_id) {
     });
     $("#revision").html(options);
     $("#revision").val(current);
+    if (!$("#revision").val()) {
+        $("#revision").prop('selectedIndex', 0);
+    }
 }
 
 function refreshContent() {
@@ -123,8 +126,19 @@ function changeRevisions() {
         selected_project = projectmatrix[executable];
 
     if (selected_project !== currentproject) {
+        var oldRevs = revisiondata[currentproject] || [];
+        var oldEntry = oldRevs.find(function(r) { return r[1] === $("#revision").val(); });
+        var oldDate = oldEntry ? new Date(oldEntry[0].slice(0, 19)) : null;
         currentproject = selected_project;
         updateRevisionMarkers($("input[name='environment']:checked").val());
+        if (oldDate) {
+            var newRevs = revisiondata[currentproject] || [];
+            var best = newRevs.reduce(function(bi, r, i) {
+                return Math.abs(new Date(r[0].slice(0, 19)) - oldDate) <
+                       Math.abs(new Date(newRevs[bi][0].slice(0, 19)) - oldDate) ? i : bi;
+            }, 0);
+            $("#revision").prop('selectedIndex', best);
+        }
 
         //Give visual cue that the select box has changed
         var bgc = $("#revision").parent().parent().css("backgroundColor");

--- a/codespeed/static/js/timeline.js
+++ b/codespeed/static/js/timeline.js
@@ -21,6 +21,13 @@ function getColor(exe_id) {
     return $("#executable > div.boxbody").find("input[value='" + exe_id + "']").data('color');
 }
 
+function updateExeColors() {
+    $("#executable div.boxbody > ul > ul > li > input").each(function() {
+        var $sq = $(this).parent().find("div.seriescolor");
+        $sq.css("background-color", $(this).is(':checked') ? getColor($(this).attr("id").slice(10)) : '');
+    });
+}
+
 function shouldPlotEquidistant() { return $("#equidistant").is(':checked'); }
 function shouldPlotQuartiles()   { return $("#show_quartile_bands").is(':checked'); }
 function shouldPlotExtrema()     { return $("#show_extrema_bands").is(':checked'); }
@@ -30,7 +37,7 @@ function getConfiguration() {
         exe:   readCheckbox("input[name='executable']:checked"),
         base:  $("#baseline option:selected").val(),
         ben:   $("input[name='benchmark']:checked").val(),
-        env:   $("input[name='environments']:checked").val(),
+        env:   readCheckbox("input[name='environments']:checked"),
         revs:  $("#revisions option:selected").val(),
         equid: shouldPlotEquidistant() ? "on" : "off",
         quarts: shouldPlotQuartiles() ? "on" : "off",
@@ -61,23 +68,28 @@ function updateUrl() {
 function destroyPlots() {
     if (plotInstance) { plotInstance.destroy(); plotInstance = null; }
     $("#plot").off("mousemove.tooltip");
+    $("#plot-legend").remove();
     miniplotInstances.forEach(function(g) { g.destroy(); });
     miniplotInstances = [];
 }
 
 // Build dygraphs-ready data from the branches dict.
-// Returns {labels, colors, data, commitMap, sortedDateKeys, seriesIds}
-// Uses customBars: data rows are [x, [low,mid,high], [low,mid,high], ...]
-function buildGraphData(branches, median, equidistant) {
-    var seriesIds = [];
-    var seriesRaw = {};  // exe_id -> dateKey -> {low, mid, high, commit, tag}
+// Returns {labels, colors, data, commitMap, sortedDateKeys, seriesIds, envIdToIndex}
+// Series keys are "exe_id:env_id". Uses customBars: [x, [low,mid,high], ...]
+function buildGraphData(branches, environments, median, equidistant) {
+    var envIdToIndex = {};
+    (environments || []).forEach(function(env, i) { envIdToIndex[String(env.id)] = i; });
+    var multiEnv = (environments || []).length > 1;
+
+    var seriesIds = [];  // composite "exe_id:env_id"
+    var seriesRaw = {};  // composite -> dateKey -> {low, mid, high, commit, tag}
     var dateIndex = {};  // dateKey -> Date
 
     for (var branch in branches) {
-        for (var exe_id in branches[branch]) {
-            seriesIds.push(exe_id);
-            seriesRaw[exe_id] = {};
-            var pts = branches[branch][exe_id];
+        for (var compositeKey in branches[branch]) {
+            seriesIds.push(compositeKey);
+            seriesRaw[compositeKey] = {};
+            var pts = branches[branch][compositeKey];
             for (var i = 0; i < pts.length; i++) {
                 var pt = pts[i];
                 var dateKey = pt[0];
@@ -108,10 +120,10 @@ function buildGraphData(branches, median, equidistant) {
                 }
 
                 dateIndex[dateKey] = new Date(dateKey.trim());
-                seriesRaw[exe_id][dateKey] = {low: low, mid: mid, high: high,
-                                              commit: commit, tag: tag,
-                                              suite_version: suite_version,
-                                              dateKey: dateKey};
+                seriesRaw[compositeKey][dateKey] = {low: low, mid: mid, high: high,
+                                                    commit: commit, tag: tag,
+                                                    suite_version: suite_version,
+                                                    dateKey: dateKey};
             }
         }
     }
@@ -123,23 +135,33 @@ function buildGraphData(branches, median, equidistant) {
     var labels = ['Date'];
     var colors = [];
     for (var k = 0; k < seriesIds.length; k++) {
-        var id = seriesIds[k];
-        labels.push($("label[for*='executable" + id + "']").text().trim());
-        colors.push(getColor(id));
+        var ckey = seriesIds[k];
+        var kparts = ckey.split(':');
+        var exeId = kparts[0];
+        var envId = kparts[1] || null;
+        var exeLabel = $("label[for*='executable" + exeId + "']").text().trim();
+        if (multiEnv && envId) {
+            var envObj = (environments || []).reduce(function(found, e) {
+                return found || (String(e.id) === envId ? e : null);
+            }, null);
+            exeLabel = exeLabel + ' (' + (envObj ? envObj.name : envId) + ')';
+        }
+        labels.push(exeLabel);
+        colors.push(getColor(exeId));
     }
 
-    // commitMap[dateKey][exe_id] = {commit, tag}
+    // commitMap[dateKey][compositeKey] = {commit, tag, low, high, suite_version}
     var commitMap = {};
-    var tsMap = {}; // timestamp (ms) -> dateKey, for legend lookup
+    var tsMap = {}; // timestamp (ms) -> dateKey, for tooltip lookup
     sortedDateKeys.forEach(function(dk) {
         tsMap[dateIndex[dk].getTime()] = dk;
         commitMap[dk] = {};
-        seriesIds.forEach(function(id) {
-            if (seriesRaw[id][dk]) {
-                var pt = seriesRaw[id][dk];
-                commitMap[dk][id] = {commit: pt.commit, tag: pt.tag,
-                                     low: pt.low, high: pt.high,
-                                     suite_version: pt.suite_version};
+        seriesIds.forEach(function(ckey) {
+            if (seriesRaw[ckey][dk]) {
+                var pt = seriesRaw[ckey][dk];
+                commitMap[dk][ckey] = {commit: pt.commit, tag: pt.tag,
+                                       low: pt.low, high: pt.high,
+                                       suite_version: pt.suite_version};
             }
         });
     });
@@ -147,8 +169,8 @@ function buildGraphData(branches, median, equidistant) {
     var graphData = sortedDateKeys.map(function(dk, idx) {
         var xval = equidistant ? idx : dateIndex[dk];
         var row = [xval];
-        seriesIds.forEach(function(id) {
-            var pt = seriesRaw[id][dk];
+        seriesIds.forEach(function(ckey) {
+            var pt = seriesRaw[ckey][dk];
             row.push(pt ? [pt.low, pt.mid, pt.high] : null);
         });
         return row;
@@ -156,7 +178,8 @@ function buildGraphData(branches, median, equidistant) {
 
     return {labels: labels, colors: colors, data: graphData,
             commitMap: commitMap, sortedDateKeys: sortedDateKeys,
-            seriesIds: seriesIds, tsMap: tsMap, dateIndex: dateIndex};
+            seriesIds: seriesIds, tsMap: tsMap, dateIndex: dateIndex,
+            envIdToIndex: envIdToIndex};
 }
 
 function renderPlot(data) {
@@ -173,7 +196,7 @@ function renderPlot(data) {
         $("span.options.median").css("display", "inline");
     }
 
-    var built = buildGraphData(data.branches, median, equidistant);
+    var built = buildGraphData(data.branches, data.environments || [], median, equidistant);
     if (built.data.length === 0) {
         $("#plot").html(getLoadText("No data available", 420));
         return;
@@ -196,7 +219,6 @@ function renderPlot(data) {
     var seriesIds = built.seriesIds;
     var tsMap = built.tsMap;
     var dateIndex = built.dateIndex;
-    var env = $("input[name='environments']:checked").val();
 
     // Find x-positions where suite_version changes between adjacent points
     var seen = {};
@@ -204,9 +226,9 @@ function renderPlot(data) {
     sortedDateKeys.forEach(function(dk, idx) {
         if (idx === 0) { return; }
         var prevDk = sortedDateKeys[idx - 1];
-        seriesIds.forEach(function(id) {
-            var curr = commitMap[dk] && commitMap[dk][id];
-            var prev = commitMap[prevDk] && commitMap[prevDk][id];
+        seriesIds.forEach(function(ckey) {
+            var curr = commitMap[dk] && commitMap[dk][ckey];
+            var prev = commitMap[prevDk] && commitMap[prevDk][ckey];
             if (curr && prev && curr.suite_version && prev.suite_version &&
                     curr.suite_version !== prev.suite_version && !seen[dk]) {
                 seen[dk] = true;
@@ -215,12 +237,12 @@ function renderPlot(data) {
         });
     });
 
-    // Map label -> color and label -> exeId for tooltip
+    // Map label -> color and label -> composite series key for tooltip
     var colorMap = {};
-    var labelToExeId = {};
+    var labelToSeriesKey = {};
     built.labels.slice(1).forEach(function(lbl, i) {
         colorMap[lbl] = built.colors[i];
-        labelToExeId[lbl] = seriesIds[i];
+        labelToSeriesKey[lbl] = seriesIds[i];
     });
 
     function lookupDateKey(x) {
@@ -239,40 +261,61 @@ function renderPlot(data) {
     function legendFormatter(ld) {
         if (ld.x === undefined) { return ''; }
         var dk = lookupDateKey(ld.x);
-        var html = '<div style="font-weight:bold;margin-bottom:3px">' +
-                   (dk ? dk.slice(0, 16) : '') + '</div>';
+
+        // Collect commit info from the first visible series with data
+        var commitInfo = null;
+        ld.series.forEach(function(s) {
+            if (commitInfo || !s.isVisible || s.y === undefined) { return; }
+            var seriesKey = labelToSeriesKey[s.labelHTML] || labelToSeriesKey[s.name];
+            if (dk && commitMap[dk] && commitMap[dk][seriesKey]) {
+                commitInfo = commitMap[dk][seriesKey];
+            }
+        });
+
+        var header = '<div style="font-weight:bold;margin-bottom:3px">' +
+                     (dk ? dk.slice(0, 16) : '');
+        if (commitInfo) {
+            header += ' <span style="font-weight:normal;font-size:0.85em;color:#666">commit: ' + commitInfo.commit;
+            if (commitInfo.tag) { header += '&nbsp;&nbsp;tag: ' + commitInfo.tag; }
+            if (versionBoundaries.length > 0 && commitInfo.suite_version) { header += '&nbsp;&nbsp;suite: ' + commitInfo.suite_version; }
+            header += '</span>';
+        }
+        header += '</div>';
+
+        var html = header;
         ld.series.forEach(function(s) {
             if (!s.isVisible || s.y === undefined) { return; }
-            var exeId = labelToExeId[s.labelHTML] || labelToExeId[s.name];
+            var seriesKey = labelToSeriesKey[s.labelHTML] || labelToSeriesKey[s.name];
+            if (!seriesKey) { return; }  // skip baseline
             var color = colorMap[s.labelHTML] || colorMap[s.name] || '#333';
             html += '<div style="margin:2px 0;color:' + color + '">' +
                     '<b>' + s.labelHTML + ': ' + s.y.toPrecision(4) + '</b>';
-            if (dk && commitMap[dk] && commitMap[dk][exeId]) {
-                var info = commitMap[dk][exeId];
+            if (dk && commitMap[dk] && commitMap[dk][seriesKey]) {
+                var info = commitMap[dk][seriesKey];
                 if (info.low !== info.high) {
                     html += ' <span style="font-weight:normal">[' +
                             info.low.toPrecision(3) + ' \u2013 ' +
                             info.high.toPrecision(3) + ']</span>';
                 }
-                html += '<br><span style="font-size:0.85em;font-weight:normal;color:#666">' +
-                        'commit: ' + info.commit;
-                if (info.tag) { html += '&nbsp;&nbsp;tag: ' + info.tag; }
-                if (versionBoundaries.length > 0 && info.suite_version) { html += '&nbsp;&nbsp;suite: ' + info.suite_version; }
-                html += '</span>';
             }
             html += '</div>';
         });
         return html;
     }
 
-    // Per-series options: baseline gets thinner line, no points
+    // Per-series options: baseline gets thinner line; 2nd env gets dashed
     var seriesOpts = {};
     built.labels.slice(1).forEach(function(lbl, i) {
         var isBase = hasBaseline && i === built.labels.length - 2;
+        var ckey = built.seriesIds[i] || '';
+        var envId = ckey.split(':')[1] || null;
+        var envIdx = envId ? (built.envIdToIndex[envId] || 0) : 0;
         seriesOpts[lbl] = {
             strokeWidth: isBase ? 1.5 : 2,
+            strokePattern: (!isBase && envIdx === 1) ? [6, 3] : null,
             drawPoints: !isBase,
             pointSize: 3,
+            highlightCircleSize: isBase ? 0 : 5,
             color: built.colors[i]
         };
     });
@@ -363,15 +406,37 @@ function renderPlot(data) {
                     }, sortedDateKeys[0]);
                 }
                 if (!dk || !commitMap[dk]) { return; }
-                var id = seriesIds[0];
-                var info = commitMap[dk][id];
+                var highlightedLabel = plotInstance && plotInstance.getHighlightSeries && plotInstance.getHighlightSeries();
+                var ckey = (highlightedLabel && labelToSeriesKey[highlightedLabel]) || seriesIds[0];
+                var info = commitMap[dk][ckey];
                 if (info) {
+                    var parts = ckey.split(':');
+                    var navEnv = parts[1] || $("input[name='environments']:checked").first().val();
                     window.location = CHANGES_URL + "?rev=" + info.commit +
-                                      "&exe=" + id + "&env=" + env;
+                                      "&exe=" + parts[0] + "&env=" + navEnv;
                 }
             }
         }
     );
+
+    // Persistent legend below the plot
+    (function() {
+        var $legend = $('<div id="plot-legend" style="margin:6px 0 4px 40px;font-size:0.9em;"></div>');
+        built.labels.slice(1).forEach(function(lbl, i) {
+            var isBase = hasBaseline && i === built.labels.length - 2;
+            var ckey = built.seriesIds[i] || '';
+            var envId = ckey.split(':')[1] || null;
+            var envIdx = envId ? (built.envIdToIndex[envId] || 0) : 0;
+            var color = built.colors[i];
+            var dashed = !isBase && envIdx === 1;
+            var svg = '<svg width="28" height="12" style="vertical-align:middle;margin-right:3px">' +
+                '<line x1="0" y1="6" x2="28" y2="6" stroke="' + color + '" stroke-width="2"' +
+                (dashed ? ' stroke-dasharray="6,3"' : '') + '/></svg>';
+            $legend.append('<span style="margin-right:16px;white-space:nowrap">' +
+                           svg + '<span style="color:' + color + '">' + lbl + '</span></span>');
+        });
+        $("#plot").after($legend);
+    }());
 
     $("#plot").on("mousemove.tooltip", function(e) {
         var $tip = $("#dygraph-tooltip");
@@ -408,7 +473,7 @@ function renderPlot(data) {
 
 function renderMiniplot(plotid, data) {
     var median = data['data_type'] === 'M';
-    var built = buildGraphData(data.branches, median, false);
+    var built = buildGraphData(data.branches, data.environments || [], median, false);
     if (built.data.length === 0) { return; }
 
     if (data.baseline !== "None") {
@@ -427,6 +492,18 @@ function renderMiniplot(plotid, data) {
             : [mxv - 1, mxv + 1];
     }
 
+    var miniSeriesOpts = {};
+    built.labels.slice(1).forEach(function(lbl, i) {
+        var ckey = built.seriesIds[i] || '';
+        var envId = ckey.split(':')[1] || null;
+        var envIdx = envId ? (built.envIdToIndex[envId] || 0) : 0;
+        miniSeriesOpts[lbl] = {
+            strokeWidth: 1.5,
+            strokePattern: envIdx === 1 ? [4, 3] : null,
+            color: built.colors[i]
+        };
+    });
+
     var g = new Dygraph(
         document.getElementById(plotid),
         built.data,
@@ -436,6 +513,7 @@ function renderMiniplot(plotid, data) {
             labels: built.labels,
             colors: built.colors,
             customBars: true,
+            series: miniSeriesOpts,
             legend: 'never',
             axes: {
                 x: { drawAxis: false, drawGrid: false },
@@ -476,7 +554,7 @@ function render(data) {
             config.nextBenchmarks = data.nextBenchmarks;
             $.getJSON("json/", config, render);
         }
-        $("#revisions").attr("disabled", true);
+        $("#revisions").val(15).attr("disabled", true);
         $("#equidistant").attr("disabled", true);
         for (var i = 0; i < data.timelines.length; i++) {
             var tl = data.timelines[i];
@@ -529,13 +607,14 @@ function setValuesOfInputFields(params) {
     var benchmark = valueOrDefault(params.ben, defaults.benchmark);
     $("input:radio[name='benchmark']").filter("[value='" + benchmark + "']").prop('checked', true);
 
-    var environment = valueOrDefault(params.env, defaults.environment);
-    $("input:radio[name='environments']").filter("[value='" + environment + "']").prop('checked', true);
-
-    $("#executable div.boxbody > ul > ul > li > input").each(function() {
-        $(this).parent().find("div.seriescolor")
-            .css("background-color", getColor($(this).attr("id").slice(10)));
+    var envDefault = (defaults.environments || []).map(String).join(',');
+    var envIds = valueOrDefault(params.env, envDefault).split(',').filter(Boolean);
+    var envSel = $("input[name='environments']");
+    envIds.forEach(function(envId) {
+        envSel.filter("[value='" + envId.trim() + "']").prop('checked', true);
     });
+    updateEnvIndicators();
+    updateExeColors();
     $("#baselinecolor").css("background-color", baselineColor);
 
     $("#equidistant").prop('checked', valueOrDefault(params.equid, defaults.equidistant) === "on");
@@ -543,18 +622,36 @@ function setValuesOfInputFields(params) {
     $("#show_extrema_bands").prop('checked', valueOrDefault(params.extr, defaults.extrema) === "on");
 }
 
+function updateEnvIndicators() {
+    $("input[name='environments']").each(function() {
+        $(this).siblings('.envlinecolor').text('');
+    });
+    $("input[name='environments']:checked").each(function(i) {
+        $(this).siblings('.envlinecolor').text(i === 0 ? '───' : '╌╌╌');
+    });
+}
+
 function initializeSite() {
     var params = getUrlParams();
-    setValuesOfInputFields(params);
     setExeColors();
+    setValuesOfInputFields(params);
 
     var onChange = function() { updateUrl(); refreshContent(); };
 
     $("#revisions, #baseline").change(onChange);
-    $("input[name='executable'], input[name='branch'], input[name='benchmark']," +
-      "input[name='environments'], #equidistant, #show_quartile_bands, #show_extrema_bands"
+    $("input[name='branch'], input[name='benchmark']," +
+      "#equidistant, #show_quartile_bands, #show_extrema_bands"
     ).change(onChange);
-    $('.checkall, .uncheckall').click(onChange);
+    $("input[name='executable']").change(function() { updateExeColors(); onChange(); });
+    $("input[name='environments']").change(function() {
+        if ($("input[name='environments']:checked").length > 2) {
+            $(this).prop('checked', false);
+            return;
+        }
+        updateEnvIndicators();
+        onChange();
+    });
+    $('.checkall, .uncheckall').click(function() { updateExeColors(); onChange(); });
 
     $("#permalink").click(function() {
         window.location = "?" + $.param(getConfiguration());
@@ -570,6 +667,9 @@ function initializeSite() {
 
 function init(def) {
     defaults = def;
+    if (!defaults.environments) {
+        defaults.environments = defaults.environment ? [defaults.environment] : [];
+    }
     $.ajaxSetup({cache: false});
     initializeSite();
 }

--- a/codespeed/templates/codespeed/timeline.html
+++ b/codespeed/templates/codespeed/timeline.html
@@ -23,8 +23,8 @@
     <ul>
     {% for env in environments %}
       <li title="{{ env.os }}, {{ env.cpu }}">
-        <input id="env{{ env.name }}" type="radio" name="environments" value="{{ env.id }}" />
-        <label for="env{{ env.name }}">{{ env }}</label>
+        <input id="env{{ env.name }}" type="checkbox" name="environments" value="{{ env.id }}" />
+        <label for="env{{ env.name }}">{{ env }}</label><div class="envlinecolor"></div>
       </li>
     {% endfor %}
     </ul>
@@ -77,7 +77,7 @@
 </div>
 
 <div id="configbar">
-  <span class="options" title="Last {{ defaultlast }} revisions tested">
+  <span class="options">
     Show the last
     <select id="revisions">{% for rev in lastrevisions %}
       <option value="{{ rev }}">{{ rev }}</option>{% endfor %}
@@ -121,7 +121,7 @@
       executables: [{% for exe in checkedexecutables %}{{ exe.id }}, {% endfor %}],
       branches: [{% for b in branch_list %}"{{ branch }}", {% endfor %}],
       benchmark: "{{ defaultbenchmark }}",
-      environment: "{{ defaultenvironment.0.id }}",
+      environments: [{% for env in defaultenvironments %}{{ env.id }}, {% endfor %}],
       equidistant: "{{ defaultequid }}",
       quartiles: "{{ defaultquarts }}",
       extrema: "{{ defaultextr }}"

--- a/codespeed/tests/test_views.py
+++ b/codespeed/tests/test_views.py
@@ -405,11 +405,11 @@ class TestTimeline(TestCase):
             1,
             "there should be 1 timeline for master")
         self.assertEqual(
-            len(responsedata['timelines'][0]['branches']['master']['1']),
+            len(responsedata['timelines'][0]['branches']['master']['1:1']),
             2,
             "There are 2 datapoints")
         self.assertEqual(
-            responsedata['timelines'][0]['branches']['master']['1'][1],
+            responsedata['timelines'][0]['branches']['master']['1:1'][1],
             [u'2011/04/13 17:04:22 ', 2000.0, 1.11111, u'2', u'', u'master', u''])
 
 

--- a/codespeed/views.py
+++ b/codespeed/views.py
@@ -451,11 +451,18 @@ def gettimelinedata(request):
     if not executables:
         timeline_list['error'] = "No executables selected"
         return HttpResponse(json.dumps(timeline_list))
-    environment = None
-    try:
-        environment = get_object_or_404(Environment, id=data.get('env'))
-    except ValueError:
-        Http404()
+
+    environments = []
+    for env_id in data.get('env', '').split(',')[:2]:
+        if not env_id:
+            continue
+        try:
+            environments.append(get_object_or_404(Environment, id=int(env_id)))
+        except (ValueError, Http404):
+            pass
+    if not environments:
+        timeline_list['error'] = "No environment selected"
+        return HttpResponse(json.dumps(timeline_list))
 
     number_of_revs, benchmarks = get_num_revs_and_benchmarks(data)
 
@@ -471,13 +478,13 @@ def gettimelinedata(request):
         next_benchmarks = int(next_benchmarks)
 
     resp = StreamingHttpResponse(stream_timeline(baseline_exe, baseline_rev, benchmarks, data,
-                                                 environment, executables, number_of_revs,
+                                                 environments, executables, number_of_revs,
                                                  next_benchmarks),
                                  content_type='application/json')
     return resp
 
 
-def stream_timeline(baseline_exe, baseline_rev, benchmarks, data, environment, executables,
+def stream_timeline(baseline_exe, baseline_rev, benchmarks, data, environments, executables,
                     number_of_revs, next_benchmarks):
     yield '{"timelines": ['
     num_results = {"results": 0}
@@ -493,7 +500,7 @@ def stream_timeline(baseline_exe, baseline_rev, benchmarks, data, environment, e
         num_benchmark += 1
 
         if not next_benchmarks or num_benchmark > next_benchmarks:
-            result = get_timeline_for_benchmark(baseline_exe, baseline_rev, bench, environment,
+            result = get_timeline_for_benchmark(baseline_exe, baseline_rev, bench, environments,
                                                 executables, number_of_revs, num_results)
             if result != "":
                 transmitted_benchmarks += 1
@@ -516,7 +523,7 @@ def stream_timeline(baseline_exe, baseline_rev, benchmarks, data, environment, e
         yield ']' + not_first + next_page + ', "error":"None"}\n'
 
 
-def get_timeline_for_benchmark(baseline_exe, baseline_rev, bench, environment, executables,
+def get_timeline_for_benchmark(baseline_exe, baseline_rev, bench, environments, executables,
                                number_of_revs, num_results):
     lessisbetter = bench.lessisbetter and ' (less is better)' or ' (more is better)'
     timeline = {
@@ -528,74 +535,67 @@ def get_timeline_for_benchmark(baseline_exe, baseline_rev, bench, environment, e
         'lessisbetter': lessisbetter,
         'branches': {},
         'baseline': "None",
+        'environments': [{'id': env.id, 'name': env.name} for env in environments],
     }
     append = False
     for branch in Branch.objects.filter(
             project__track=True, name=F('project__default_branch')):
-        # For now, we'll only work with default branches
-        for executable in executables:
-            if executable.project != branch.project:
-                continue
+        for environment in environments:
+            for executable in executables:
+                if executable.project != branch.project:
+                    continue
 
-            resultquery = Result.objects.filter(
-                benchmark=bench
-            ).filter(
-                environment=environment
-            ).filter(
-                executable=executable
-            ).filter(
-                revision__branch=branch
-            ).select_related(
-                "revision"
-            ).order_by('-revision__date')[:number_of_revs]
-            if not len(resultquery):
-                continue
-            timeline['branches'].setdefault(branch.name, {})
+                resultquery = Result.objects.filter(
+                    benchmark=bench,
+                    environment=environment,
+                    executable=executable,
+                    revision__branch=branch,
+                ).select_related(
+                    "revision"
+                ).order_by('-revision__date')[:number_of_revs]
+                if not len(resultquery):
+                    continue
+                timeline['branches'].setdefault(branch.name, {})
 
-            results = []
-            for res in resultquery:
-                if bench.data_type == 'M':
-                    q1, q3, val_max, val_min = get_stats_with_defaults(res)
-                    results.append(
-                        [
+                results = []
+                for res in resultquery:
+                    if bench.data_type == 'M':
+                        q1, q3, val_max, val_min = get_stats_with_defaults(res)
+                        results.append([
                             res.revision.date.strftime('%Y/%m/%d %H:%M:%S %z'),
                             res.value, val_max, q3, q1, val_min,
                             res.revision.get_short_commitid(), res.revision.tag, branch.name,
                             res.suite_version,
-                        ]
-                    )
-                else:
-                    std_dev = ""
-                    if res.std_dev is not None:
-                        std_dev = res.std_dev
-                    results.append(
-                        [
+                        ])
+                    else:
+                        std_dev = ""
+                        if res.std_dev is not None:
+                            std_dev = res.std_dev
+                        results.append([
                             res.revision.date.strftime('%Y/%m/%d %H:%M:%S %z'),
                             res.value, std_dev,
                             res.revision.get_short_commitid(), res.revision.tag, branch.name,
                             res.suite_version,
-                        ]
-                    )
-            timeline['branches'][branch.name][executable.id] = results
-            append = True
+                        ])
+                # Key is "exe_id:env_id" so multiple environments render as separate series
+                timeline['branches'][branch.name][f"{executable.id}:{environment.id}"] = results
+                append = True
     if baseline_rev is not None and append:
         try:
             baselinevalue = Result.objects.get(
                 executable=baseline_exe,
                 benchmark=bench,
                 revision=baseline_rev,
-                environment=environment
+                environment=environments[0],
             ).value
         except Result.DoesNotExist:
             timeline['baseline'] = "None"
         else:
-            # determine start and end revision (x axis)
-            # from longest data series
             results = []
             for branch in timeline['branches']:
-                for exe in timeline['branches'][branch]:
-                    if len(timeline['branches'][branch][exe]) > len(results):
-                        results = timeline['branches'][branch][exe]
+                for key in timeline['branches'][branch]:
+                    if len(timeline['branches'][branch][key]) > len(results):
+                        results = timeline['branches'][branch][key]
             end = results[0][0]
             start = results[len(results) - 1][0]
             timeline['baseline'] = [
@@ -625,6 +625,10 @@ def timeline(request):
     if not enviros:
         return no_environment_error(request)
     defaultenviro = get_default_environment(enviros, data)
+    if 'env' in data:
+        defaultenvironments = get_default_environment(enviros, data, multi=True)[:2]
+    else:
+        defaultenvironments = defaultenviro  # already respects DEF_ENVIRONMENT
 
     # Default Project
     defaultproject = Project.objects.filter(track=True)
@@ -643,6 +647,15 @@ def timeline(request):
             except Executable.DoesNotExist:
                 pass
 
+    if not checkedexecutables:
+        if hasattr(settings, 'DEF_EXECUTABLES') and settings.DEF_EXECUTABLES:
+            for def_exe in settings.DEF_EXECUTABLES:
+                try:
+                    proj = Project.objects.get(name=def_exe['project'])
+                    checkedexecutables.append(
+                        Executable.objects.get(name=def_exe['name'], project=proj))
+                except (Project.DoesNotExist, Executable.DoesNotExist):
+                    pass
     if not checkedexecutables:
         checkedexecutables = Executable.objects.filter(project__track=True)
 
@@ -671,12 +684,17 @@ def timeline(request):
         except ValueError:
             pass
 
-    lastrevisions = [10, 50, 200, 1000]
+    lastrevisions = [10, 15, 50, 200]
     defaultlast = settings.DEF_TIMELINE_LIMIT
-    if 'revs' in data:
-        if int(data['revs']) not in lastrevisions:
-            lastrevisions.append(data['revs'])
-        defaultlast = data['revs']
+    if 'revs' in data and data['revs']:
+        try:
+            revs_int = int(data['revs'])
+        except ValueError:
+            revs_int = None
+        if revs_int is not None:
+            if revs_int not in lastrevisions:
+                lastrevisions.append(revs_int)
+            defaultlast = revs_int
 
     benchmarks = Benchmark.objects.all()
 
@@ -733,6 +751,7 @@ def timeline(request):
         'baseline': baseline,
         'defaultbenchmark': defaultbenchmark,
         'defaultenvironment': defaultenviro,
+        'defaultenvironments': defaultenvironments,
         'lastrevisions': lastrevisions,
         'defaultlast': defaultlast,
         'executables': executables,

--- a/codespeed/views_data.py
+++ b/codespeed/views_data.py
@@ -21,15 +21,14 @@ def get_default_environment(enviros, data, multi=False):
     # Use permalink values
     if 'env' in data:
         for env_value in data['env'].split(","):
+            try:
+                env_id = int(env_value)
+            except ValueError:
+                continue
             for env in enviros:
-                try:
-                    env_id = int(env_value)
-                except ValueError:
-                    # Not an int
-                    continue
-                for env in enviros:
-                    if env_id == env.id:
-                        defaultenviros.append(env)
+                if env_id == env.id:
+                    defaultenviros.append(env)
+                    break
             if not multi:
                 break
     # Use settings.py value
@@ -91,7 +90,8 @@ def getbaselineexecutables(include_tags=None):
                 if base['key'] == "none":
                     continue
                 if (base['executable'].name == exename and
-                        base['revision'].commitid == commitid):
+                        (base['revision'].commitid == commitid or
+                         base['revision'].tag == commitid)):
                     baseline.remove(base)
                     baseline.insert(1, base)
                     break


### PR DESCRIPTION
- Allow multiple timelines
- Add ux to show what line colors/solid/dashed means
- Fix DEF_ENVIRONMENT and DEF_EXECUTABLES defaults on timeline page
- Fix baseline tag vs commitid matching in DEF_BASELINES