### PR TITLE
change defaults to benchmarker2

### DIFF
--- a/codespeed/tests/test_views.py
+++ b/codespeed/tests/test_views.py
@@ -383,7 +383,7 @@ class TestTimeline(TestCase):
         path = reverse('gettimelinedata')
         data = {
             "exe": "1,2",
-            "base": "2+4",
+            "base": "2:4",
             "ben": "float",
             "env": "1",
             "revs": "2"

--- a/codespeed/views.py
+++ b/codespeed/views.py
@@ -290,7 +290,7 @@ def comparison(request):
     enviros = Environment.objects.all()
     if not enviros:
         return no_environment_error(request)
-    checkedenviros = get_default_environment(enviros, data, multi=True)
+    checkedenviros = get_default_environment(enviros, data)
 
     if not len(Project.objects.filter(track=True)):
         return no_default_project_error(request)
@@ -491,7 +491,7 @@ def gettimelinedata(request):
     baseline_rev = None
     baseline_exe = None
     if data.get('base') not in (None, 'none', 'undefined'):
-        exe_id, rev_id = data['base'].split("+")
+        exe_id, rev_id = data['base'].split(":")
         baseline_rev = Revision.objects.get(id=rev_id)
         baseline_exe = Executable.objects.get(id=exe_id)
 

--- a/speed_pypy/settings.py
+++ b/speed_pypy/settings.py
@@ -90,13 +90,12 @@ STATICFILES_DIRS = (
 SHOW_REPORTS = False
 SHOW_HISTORICAL = True
 DEF_BASELINES = [
-                 {'executable': 'cpython', 'revision': '3.11.9'},
-                 {'executable': 'cpython', 'revision': '3.12.4'},
+                 {'executable': 'cpython', 'revision': '3.11.15'},
                 ]
 DEF_EXECUTABLES = [
                    {'name': 'pypy3.11-jit-64', 'project': 'PyPy3.11'},
                   ]
-DEF_ENVIRONMENT = 'benchmarker'
+DEF_ENVIRONMENT = 'benchmarker2'
 CHART_ORIENTATION = 'horizontal'
 DEF_BENCHMARK = 'grid'
 


### PR DESCRIPTION
This will change the default display on the homepage to show a comparison to benchmarker2. The summary is quite different: PyPy 3.11 is now 4.3x CPython3.11.15 where the current homepage shows 3.0. I will hold off merging this till I can write a blog post about what is going on. The main reason for the difference is that the benchline cpython runs on benchmarker were done a number of years ago, and since then the machine has gotten some OS and kernel updates that slowed down the subsequent PyPy benchmark runs. 
<img width="1868" height="954" alt="benchmarker2" src="https://github.com/user-attachments/assets/a5eb6bcb-3a49-483b-a226-50cd4cb8e36b" />


Note this is a needed step to add pyperformance benchmarks. The benchmarker machine would take too long to run both sets of benchmarks, see pypy/buildbot/pull/2
